### PR TITLE
Improvements to debugging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ myRemote = new RemoteLayer
 fe.debug = true
 ```
 
+#### Check the currently focused layer
+```coffeescript
+print fe.focus
+```
+
+#### Check whether a layer has focus
+```coffeescript
+print layerA.focus
+```
+
 #### Known issues
 
 Attempting to perform a `placeFocus()` call as FocusEngine is changing its own focus will fail. (The call is discarded.) If you need to override FocusEngine's logic, Use a slight delay to ensure the call is respected.


### PR DESCRIPTION
Tracked layers can now be queried directly for their focus boolean value.
The engine now relies on this value rather than on the name of the layer's current state. (It never failed previously, but this seems like a more reliable mechanism and so far it works at least as well.)
Debug statement will try to look for the layer's __framerInstanceInfo.name if no name is set. It's a private property, but a fallback is included.
Running the focus engine with no initial focus set now fails gracefully with error message.

Non-breaking change, should be seamless for the user.