### PR TITLE
Feature/overrides

### DIFF
--- a/FocusEngine.coffee
+++ b/FocusEngine.coffee
@@ -71,6 +71,15 @@
 	fe.debug = true
 ###
 
+overrides =
+	up: null
+	down: null
+	left: null
+	right: null
+
+# all layers receive default empty overrides
+Layer::overrides = overrides
+
 exports.debug = false
 
 # focus store
@@ -89,6 +98,7 @@ exports.focusStyle =
 	shadowY: 0
 	shadowSpread: 0
 
+# unfocus style
 exports.unfocusStyle =
 	shadowBlur: 20
 	shadowColor: "rgba(0,0,0,0)"
@@ -181,40 +191,43 @@ exports.changeFocus = Utils.throttle 0.1, (direction) ->
 	# if we've lost all focus, reset
 	if exports.focus == null or exports.focus == undefined
 		exports.placeFocus(exports.initialFocus)
-	focusMidX = exports.focus.screenFrame.x + exports.focus.screenFrame.width/2
-	focusMidY = exports.focus.screenFrame.y + exports.focus.screenFrame.height/2
-	if direction == "up"
-		for layer in exports.focusable
-			layerMidY = layer.screenFrame.y + layer.screenFrame.height/2
-			if layerMidY < focusMidY and checkVisible(layer) == true
-				tempArray.push(layer)
-	else if direction == "down"
-		for layer in exports.focusable
-			layerMidY = layer.screenFrame.y + layer.screenFrame.height/2
-			if layerMidY > focusMidY and checkVisible(layer) == true
-				tempArray.push(layer)
-	else if direction == "left"
-		for layer in exports.focusable
-			layerMidX = layer.screenFrame.x + layer.screenFrame.width/2
-			if layerMidX < focusMidX and checkVisible(layer) == true
-				tempArray.push(layer)
-	else if direction == "right"
-		for layer in exports.focusable
-			layerMidX = layer.screenFrame.x + layer.screenFrame.width/2
-			if layerMidX > focusMidX and checkVisible(layer) == true
-				tempArray.push(layer)
-	else if direction == "select"
-		exports.focus.emit "selected"
-	if tempArray.length == 0
-		return
-	targetLayer = tempArray[0]
-	shortestDistance = measureDistance(targetLayer, direction)
-	for layer in tempArray
-		distance = measureDistance(layer, direction)
-		if distance < shortestDistance
-			targetLayer = layer
-			shortestDistance = distance
-	exports.placeFocus(targetLayer)
+	if exports.focus.overrides?[direction] != undefined and exports.focus.overrides?[direction] != null # override
+		exports.placeFocus(exports.focus.overrides[direction])
+	else
+		focusMidX = exports.focus.screenFrame.x + exports.focus.screenFrame.width/2
+		focusMidY = exports.focus.screenFrame.y + exports.focus.screenFrame.height/2
+		if direction == "up"
+			for layer in exports.focusable
+				layerMidY = layer.screenFrame.y + layer.screenFrame.height/2
+				if layerMidY < focusMidY and checkVisible(layer) == true
+					tempArray.push(layer)
+		else if direction == "down"
+			for layer in exports.focusable
+				layerMidY = layer.screenFrame.y + layer.screenFrame.height/2
+				if layerMidY > focusMidY and checkVisible(layer) == true
+					tempArray.push(layer)
+		else if direction == "left"
+			for layer in exports.focusable
+				layerMidX = layer.screenFrame.x + layer.screenFrame.width/2
+				if layerMidX < focusMidX and checkVisible(layer) == true
+					tempArray.push(layer)
+		else if direction == "right"
+			for layer in exports.focusable
+				layerMidX = layer.screenFrame.x + layer.screenFrame.width/2
+				if layerMidX > focusMidX and checkVisible(layer) == true
+					tempArray.push(layer)
+		else if direction == "select"
+			exports.focus.emit "selected"
+		if tempArray.length == 0
+			return
+		targetLayer = tempArray[0]
+		shortestDistance = measureDistance(targetLayer, direction)
+		for layer in tempArray
+			distance = measureDistance(layer, direction)
+			if distance < shortestDistance
+				targetLayer = layer
+				shortestDistance = distance
+		exports.placeFocus(targetLayer)
 
 measureDistance = (target, direction) ->
 	focusTopCenter =

--- a/FocusEngine.coffee
+++ b/FocusEngine.coffee
@@ -71,9 +71,6 @@
 	fe.debug = true
 ###
 
-Layer::setOverrides = (options = {up: null, down: null, left: null, right: null}) ->
-	@.overrides = options
-
 exports.debug = false
 
 # focus store

--- a/FocusEngine.coffee
+++ b/FocusEngine.coffee
@@ -71,7 +71,7 @@
 	fe.debug = true
 ###
 
-Layer::setOverrides = (options = {}) ->
+Layer::setOverrides = (options = {up: null, down: null, left: null, right: null}) ->
 	@.overrides = options
 
 exports.debug = false

--- a/FocusEngine.coffee
+++ b/FocusEngine.coffee
@@ -71,14 +71,8 @@
 	fe.debug = true
 ###
 
-overrides =
-	up: null
-	down: null
-	left: null
-	right: null
-
-# all layers receive default empty overrides
-Layer::overrides = overrides
+Layer::setOverrides = (options = {}) ->
+	@.overrides = options
 
 exports.debug = false
 
@@ -98,7 +92,6 @@ exports.focusStyle =
 	shadowY: 0
 	shadowSpread: 0
 
-# unfocus style
 exports.unfocusStyle =
 	shadowBlur: 20
 	shadowColor: "rgba(0,0,0,0)"
@@ -110,6 +103,12 @@ exports.unfocusStyle =
 exports.initialize = (focusableArray) ->
 	exports.focusable = focusableArray
 	for layer in exports.focusable
+		if layer.overrides == undefined
+			layer.overrides =
+				up: null
+				down: null
+				left: null
+				right: null
 		layer.focus = false
 		styleLayer(layer)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ layerA.overrides =
 	right: <layer>
 ```
 
-It is not necessary to set all four; but only those directions which require custom behavior. Now `layerA` will always shift up, down, left or right to the layer specified -- no matter what FocusEngine thinks should happen.
+It is not necessary to set all four overrides; but only for those directions which require custom behavior. Now, shifting focus from `layerA`  will always land on the direction-specified target -- no matter what FocusEngine thinks should happen.
 
 > Obviously, you can create very unexpected behaviors this way. Use with care! 
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ fe.debug = true
 
 #### Known issues
 
-Attempting to perform a `placeFocus()` call as FocusEngine is changing its own focus will fail. (The call is discarded.) If you need to override FocusEngine's logic, Use a slight delay to ensure the call is respected.
+Attempting to perform a `placeFocus()` call as FocusEngine is changing its own focus will fail. (The call is discarded.) If you need to override FocusEngine's logic, use the `overrides` feature or add a slight delay to ensure the call is respected.
 
 ```coffeescript
 layerA.on "unfocus", ->

--- a/README.md
+++ b/README.md
@@ -116,11 +116,6 @@ myRemote = new RemoteLayer
 	swipeRightAction: -> fe.changeFocus("right")
 ```
 
-#### Enable debug mode to log focus changes
-```coffeescript
-fe.debug = true
-```
-
 #### Check the currently focused layer
 ```coffeescript
 print fe.focus
@@ -129,6 +124,34 @@ print fe.focus
 #### Check whether a layer has focus
 ```coffeescript
 print layerA.focus
+```
+
+#### Overriding focus logic
+Sometimes you will want to change focus in a way that doesn't make exact geometric sense. For example, when switching from a large header row to a smaller secondary row, you may prefer the first cell in the secondary row receive focus. Or, you may want to provide a way for focus to "loop around" at a row's end. These kinds of functions are possible through _overrides._
+
+Set a layer's overrides using the `overrides` object:
+```coffeescript
+layerA.overrides =
+	up: <layer>
+	down: <layer>
+	left: <layer>
+	right: <layer>
+```
+
+It is not necessary to set all four; but only those directions which require custom behavior. Now `layerA` will always shift up, down, left or right to the layer specified -- no matter what FocusEngine thinks should happen.
+
+> Obviously, you can create very unexpected behaviors this way. Use with care! 
+
+If a layer has custom overrides, or has been initialized with FocusEngine, you may check any of its current overrides:
+```coffeescript
+print layerA.overrides?.up
+```
+
+The `?` permits the check to fail gracefully on layers which have no overrides.
+
+#### Enable debug mode to log focus changes
+```coffeescript
+fe.debug = true
 ```
 
 #### Known issues


### PR DESCRIPTION
Adds the ability to assign `overrides` to layers. Overrides are honored above nearest-target calculations.

[focus-grid-test.zip](https://github.com/bpxl-labs/FocusEngine/files/1184267/focus-grid-test.zip)

In the attached test, a1, c4 and d4 should obey their overrides rather than shifting focus to the nearest layer in the input direction.